### PR TITLE
Add `multi-get`, wrapping `AsyncStorage.multiGet`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: clojure
 sudo: false
 script:
   - lein test
-  - lein doo phantom once
+  - lein doo phantom test once

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ often as you like and they'll always yield the same value
 - [x] AsyncStorage.clear
 - [ ] AsyncStorage.getAllKeys
 - [ ] AsyncStorage.flushGetRequests
-- [ ] AsyncStorage.multiGet
+- [x] AsyncStorage.multiGet
 - [ ] AsyncStorage.multiSet
 - [ ] AsyncStorage.multiRemove
 - [ ] AsyncStorage.multiMerge

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject core-async-storage "0.1.1"
+(defproject core-async-storage "0.2.0"
   :description "Clojurescript wrapper for react-native's AsyncStorage using
                 core.async"
   :url "https://github.com/glittershark/core-async-storage"

--- a/src/glittershark/core_async_storage.cljs
+++ b/src/glittershark/core_async_storage.cljs
@@ -27,12 +27,16 @@
 
 (defn- ?read-string [v] (if v (reader/read-string v) v))
 
+(defn- method [mname] (-> async-storage
+                          (aget mname)
+                          (.bind async-storage)))
+
 (defcbfn
   ^{:doc "Fetches `key' and returns [error result] in a core.async channel, or
           [nil result] if no error"
     :arglists '([key])
     :added "1.0.0"}
-  get-item (aget async-storage "getItem")
+  get-item (method "getItem")
   :transducer (map (map-last ?read-string))
   :transform-args (map-first pr-str))
 
@@ -42,7 +46,7 @@
           in a core async channel, or [nil results] if no error"
     :arglists '([keys])
     :added "1.1.0"}
-  multi-get (aget async-storage "multiGet")
+  multi-get (method "multiGet")
   :transducer (map (map-last #(map ?read-string %)))
   :transform-args (map-first #(->> % (map pr-str) (apply array))))
 
@@ -51,7 +55,7 @@
           upon completion, or [] if no error"
     :arglists '([key value])
     :added "1.0.0"}
-  set-item (aget async-storage "setItem")
+  set-item (method "setItem")
   :transform-args #(map pr-str %))
 
 (defcbfn
@@ -59,7 +63,7 @@
           channel, or [] if no error"
     :arglists '([key value])
     :added "1.0.0"}
-  remove-item (aget async-storage "removeItem")
+  remove-item (method "removeItem")
   :transform-args (map-first pr-str))
 
 (defcbfn
@@ -69,4 +73,4 @@
           Returns [error] in a core.async channel, or [] if no error"
     :arglists '([key value])
     :added "1.0.0"}
-  clear (aget async-storage "clear"))
+  clear (method "clear"))

--- a/src/glittershark/core_async_storage.cljs
+++ b/src/glittershark/core_async_storage.cljs
@@ -41,13 +41,14 @@
   :transform-args (map-first pr-str))
 
 (defcbfn
-  ^{:doc "Fetches all `keys` and returns [errors results], where each item in
-          errors and results correspond to the element at the same index in key,
-          in a core async channel, or [nil results] if no error"
+  ^{:doc "Fetches all `keys` and returns [errors? results] in a core.async
+          channel, where `results` is a map from requested keys to their values
+          in storage"
     :arglists '([keys])
     :added "1.1.0"}
   multi-get (method "multiGet")
-  :transducer (map (map-last #(map ?read-string %)))
+  :transducer (map (map-last
+                     #(->> % (map (partial mapv ?read-string)) (into {}))))
   :transform-args (map-first #(->> % (map pr-str) (apply array))))
 
 (defcbfn

--- a/src/glittershark/core_async_storage.cljs
+++ b/src/glittershark/core_async_storage.cljs
@@ -37,6 +37,16 @@
   :transform-args (map-first pr-str))
 
 (defcbfn
+  ^{:doc "Fetches all `keys` and returns [errors results], where each item in
+          errors and results correspond to the element at the same index in key,
+          in a core async channel, or [nil results] if no error"
+    :arglists '([keys])
+    :added "1.1.0"}
+  multi-get (aget async-storage "multiGet")
+  :transducer (map (map-last #(map ?read-string %)))
+  :transform-args (map-first #(->> % (map pr-str) (apply array))))
+
+(defcbfn
   ^{:doc "Sets `value' for `key' and returns [error] in a core.async channel
           upon completion, or [] if no error"
     :arglists '([key value])

--- a/test/glittershark/core_async_storage_test.cljs
+++ b/test/glittershark/core_async_storage_test.cljs
@@ -3,8 +3,12 @@
             [cljs.core.async :refer [<!]]
             [glittershark.core-async-storage
              :refer [async-storage
-                     get-item set-item remove-item clear]])
+                     get-item multi-get set-item remove-item clear]])
   (:require-macros [cljs.core.async.macros :refer [go]]))
+
+(defn js-array-equals? [a1 a2]
+  (and (js/Array.isArray a1)
+       (js/Array.isArray a2)))
 
 (defn mock-storage-fn [fname mock-fn]
   (let [call-args (atom [])
@@ -30,6 +34,23 @@
           (let [args (mock-storage-fn "getItem" #(% nil nil))]
             (is (= [nil nil] (<! (get-item :test)))
                 "returns nil for both error and value"))))
+
+      (done))))
+
+(deftest multi-get-test
+  (async done
+    (go
+      (testing "when the keys all exist in storage"
+        (let [args (mock-storage-fn "multiGet" #(% nil #js [":foo" ":bar"]))]
+          (is (= [nil [:foo :bar]] (<! (multi-get [:test1 :test2])))
+              "reads return values of AsyncStorage.multiGet as EDN")
+
+          (is (= [[[":test1" ":test2"]]] (js->clj @args))
+              "Converts all of the passed keys to EDN before passing them to
+               AsyncStorage.multiGet")
+
+          (is (js/Array.isArray (-> @args first first))
+              "Converts the list of keys to a JS array")))
 
       (done))))
 

--- a/test/glittershark/core_async_storage_test.cljs
+++ b/test/glittershark/core_async_storage_test.cljs
@@ -41,8 +41,11 @@
   (async done
     (go
       (testing "when the keys all exist in storage"
-        (let [args (mock-storage-fn "multiGet" #(% nil #js [":foo" ":bar"]))]
-          (is (= [nil [:foo :bar]] (<! (multi-get [:test1 :test2])))
+        (let [args (mock-storage-fn "multiGet"
+                                    #(% nil #js[#js[":test1" ":foo"]
+                                                #js[":test2" ":bar"]]))]
+          (is (= [nil {:test1 :foo, :test2 :bar}]
+                 (<! (multi-get [:test1 :test2])))
               "reads return values of AsyncStorage.multiGet as EDN")
 
           (is (= [[[":test1" ":test2"]]] (js->clj @args))


### PR DESCRIPTION
I wanted to call it `get-multi`, but name parity is more important.

Also note the conversion to JS array here - that's necessary for
ReactNative, for obvious reasons