### PR TITLE
Use cljs.tools.reader to handle namespaced maps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,8 @@
             :url "https://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "1.8.40"]
-                 [org.clojure/core.async "0.3.443"]]
+                 [org.clojure/core.async "0.3.443"]
+                 [org.clojure/tools.reader "1.0.5"]]
   :plugins [[lein-cljsbuild "1.1.3"]
             [lein-doo "0.1.6"]
             [lein-codox "0.9.4"]]

--- a/src/glittershark/core_async_storage.cljs
+++ b/src/glittershark/core_async_storage.cljs
@@ -10,7 +10,7 @@
   {:author "Griffin Smith"}
 
   (:require [cljs.core.async :refer [promise-chan <! put!]]
-            [cljs.reader :as reader]
+            [cljs.tools.reader :as reader]
             [goog.object])
   (:require-macros [glittershark.core-async-storage :refer [defcbfn]]))
 

--- a/test/glittershark/core_async_storage_test.cljs
+++ b/test/glittershark/core_async_storage_test.cljs
@@ -28,12 +28,16 @@
 
           (is (= [[":test"]] @args)
               "converts the passed key to EDN before passing it to
-               AsyncStorage.getItem"))
+               AsyncStorage.getItem")))
 
-        (testing "when the key doesn't exist in storage"
-          (let [args (mock-storage-fn "getItem" #(% nil nil))]
-            (is (= [nil nil] (<! (get-item :test)))
-                "returns nil for both error and value"))))
+      (testing "when the key doesn't exist in storage"
+        (let [args (mock-storage-fn "getItem" #(% nil nil))]
+          (is (= [nil nil] (<! (get-item :test)))
+              "returns nil for both error and value")))
+
+      (testing "decodes namespaced maps correctly"
+        (let [args (mock-storage-fn "getItem" #(% nil "#:foo.bar{:baz 1}"))]
+          (is (= [nil {:foo.bar/baz 1}] (<! (get-item :test))))))
 
       (done))))
 


### PR DESCRIPTION
Namespaced maps like `#:foo.bar{:baz 1}` aren't handled correctly by `cljs.reader`; Clojurescript is moving to `cljs.tools.reader` as its canonical reader.